### PR TITLE
Receive order from websockeets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 config/rsa*
+rango
+.vscode

--- a/cmd/rango/rango.go
+++ b/cmd/rango/rango.go
@@ -26,6 +26,9 @@ var (
 	amqpAddr = flag.String("amqp-addr", "", "AMQP server address")
 	pubKey   = flag.String("pubKey", "config/rsa-key.pub", "Path to public key")
 	exName   = flag.String("exchange", "peatio.events.ranger", "Exchange name of upstream messages")
+
+	exchangeNameWrite = flag.String("exchange-write", "peatio.events.ranger", "Exchange name for write messages")
+	routingKeyWrite   = flag.String("routing-key-write", "peatio.order.new", "Routing key for write messages")
 )
 
 const prefix = "Bearer "
@@ -167,7 +170,6 @@ func main() {
 	metrics.Enable()
 
 	rbac := getRBACConfig()
-	hub := routing.NewHub(rbac)
 	pub, err := getPublicKey()
 	if err != nil {
 		log.Error().Msgf("Loading public key failed: %s", err.Error())
@@ -182,6 +184,9 @@ func main() {
 		log.Fatal().Msgf("creating new AMQP session failed: %s", err.Error())
 		return
 	}
+
+	hub := routing.NewHub(rbac, mq, *exchangeNameWrite, *routingKeyWrite)
+
 	err = mq.Stream(*exName, qName, hub.ReceiveMsg)
 	defer mq.Close(qName)
 

--- a/cmd/rango/rango.go
+++ b/cmd/rango/rango.go
@@ -27,8 +27,8 @@ var (
 	pubKey   = flag.String("pubKey", "config/rsa-key.pub", "Path to public key")
 	exName   = flag.String("exchange", "peatio.events.ranger", "Exchange name of upstream messages")
 
-	exchangeNameWrite = flag.String("exchange-write", "peatio.events.ranger", "Exchange name for write messages")
-	routingKeyWrite   = flag.String("routing-key-write", "peatio.order.new", "Routing key for write messages")
+	exchangeNameWrite = flag.String("order-exchange", "peatio.events.ranger", "Exchange name for order messages")
+	routingKeyWrite   = flag.String("order-routing-key", "peatio.order.new", "Routing key for order messages")
 )
 
 const prefix = "Bearer "

--- a/pkg/message/msg.go
+++ b/pkg/message/msg.go
@@ -7,6 +7,7 @@ import (
 type Request struct {
 	Method  string
 	Streams []string
+	Message []byte
 }
 
 func PackOutgoingResponse(err error, message interface{}) ([]byte, error) {

--- a/pkg/message/parser.go
+++ b/pkg/message/parser.go
@@ -51,6 +51,14 @@ func Parse(msg []byte) (Request, error) {
 				parsed.Streams = append(parsed.Streams, streams.Index(i).Interface().(string))
 			}
 		}
+	case "order":
+		parsed.Method = "order"
+		bb, err := json.Marshal(v["data"])
+		if err != nil {
+			return parsed, err
+		}
+
+		parsed.Message = bb
 	default:
 		return parsed, errors.New("Could not parse Type: Invalid event")
 	}

--- a/pkg/message/parser_test.go
+++ b/pkg/message/parser_test.go
@@ -1,0 +1,33 @@
+package message
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	bb := []byte(`{"event":"order","data":{"market":"bbbuuu","side":"sell","volume":"0.001","ord_type":"limit","price":"5000"}}`)
+	req, err := Parse(bb)
+	if err != nil {
+		t.Fatalf("Should not return error: %s", err)
+	}
+
+	t.Run("Test method", func(t *testing.T) {
+		assert.Equal(t, "order", req.Method)
+	})
+
+	t.Run("Test message", func(t *testing.T) {
+		vv := map[string]interface{}{}
+
+		err := json.Unmarshal(req.Message, &vv)
+		if err != nil {
+			t.Fatalf("Should not return error: %s", err)
+		}
+
+		v, ok := vv["market"]
+		assert.Equal(t, true, ok)
+		assert.Equal(t, "bbbuuu", v)
+	})
+}

--- a/pkg/message/parser_test.go
+++ b/pkg/message/parser_test.go
@@ -8,20 +8,24 @@ import (
 )
 
 func TestParse(t *testing.T) {
+	const (
+		isAuthClient    = true
+		isNotAuthClient = false
+	)
+
 	bb := []byte(`{"event":"order","data":{"market":"bbbuuu","side":"sell","volume":"0.001","ord_type":"limit","price":"5000"}}`)
-	req, err := Parse(bb)
-	if err != nil {
-		t.Fatalf("Should not return error: %s", err)
-	}
 
-	t.Run("Test method", func(t *testing.T) {
+	t.Run("Test auth client", func(t *testing.T) {
+		req, err := Parse(bb, isAuthClient)
+		if err != nil {
+			t.Fatalf("Should not return error: %s", err)
+		}
+
 		assert.Equal(t, "order", req.Method)
-	})
 
-	t.Run("Test message", func(t *testing.T) {
 		vv := map[string]interface{}{}
 
-		err := json.Unmarshal(req.Message, &vv)
+		err = json.Unmarshal(req.Message, &vv)
 		if err != nil {
 			t.Fatalf("Should not return error: %s", err)
 		}
@@ -29,5 +33,14 @@ func TestParse(t *testing.T) {
 		v, ok := vv["market"]
 		assert.Equal(t, true, ok)
 		assert.Equal(t, "bbbuuu", v)
+	})
+
+	t.Run("Test unauth client", func(t *testing.T) {
+		req, err := Parse(bb, isNotAuthClient)
+		if err == nil {
+			t.Fatalf("Should not return error: %s", err)
+		}
+
+		assert.Equal(t, "order", req.Method)
 	})
 }

--- a/pkg/message/parser_test.go
+++ b/pkg/message/parser_test.go
@@ -38,7 +38,7 @@ func TestParse(t *testing.T) {
 	t.Run("Test unauth client", func(t *testing.T) {
 		req, err := Parse(bb, isNotAuthClient)
 		if err == nil {
-			t.Fatalf("Should not return error: %s", err)
+			t.Fatalf("Should return error")
 		}
 
 		assert.Equal(t, "order", req.Method)

--- a/pkg/routing/client.go
+++ b/pkg/routing/client.go
@@ -280,7 +280,7 @@ func (c *Client) read() {
 			continue
 		}
 
-		req, err := msg.ParseRequest(message)
+		req, err := msg.ParseRequest(message, c.isAuthenticated())
 		if err != nil {
 			c.send <- []byte(responseMust(err, nil))
 			continue
@@ -328,4 +328,8 @@ func (c *Client) write() {
 			}
 		}
 	}
+}
+
+func (c *Client) isAuthenticated() bool {
+	return c.Auth.UID != ""
 }

--- a/pkg/routing/client_test.go
+++ b/pkg/routing/client_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestClient(t *testing.T) {
-	hub := NewHub(nil)
+	hub := NewHub(nil, nil, "", "")
 	client := &Client{
 		hub:     hub,
 		send:    make(chan []byte, 256),

--- a/pkg/routing/hub_test.go
+++ b/pkg/routing/hub_test.go
@@ -47,7 +47,7 @@ func (c *MockedClient) UnsubscribePrivate(s string) {
 }
 
 func setup(c *MockedClient, streams []string) *Hub {
-	h := NewHub(nil)
+	h := NewHub(nil, nil, "", "")
 	h.handleSubscribe(&Request{
 		client: c,
 		Request: message.Request{
@@ -240,7 +240,7 @@ func TestGetTopic(t *testing.T) {
 }
 
 func TestHandleMessage(t *testing.T) {
-	h := NewHub(nil)
+	h := NewHub(nil, nil, "", "")
 	c := &MockedClient{}
 	c.On("SubscribePublic", "abc.ticker").Return()
 	c.On("Send", "{\"abc.ticker\":{\"some\":\"data\"}}").Return()
@@ -263,7 +263,7 @@ func TestHandleMessage(t *testing.T) {
 }
 
 func TestIncrementalObjectStorage(t *testing.T) {
-	h := NewHub(nil)
+	h := NewHub(nil, nil, "", "")
 
 	// Increments before the first snapshot must be ignored
 	h.routeMessage(&Event{


### PR DESCRIPTION
Добавлена обработка событий типа: `order`

Добавлены флаги:
 - exchange-write (`exchange` для записи сообщений из вебсокета)
 - routing-key-write (`routing-key` для записи сообщений из вебсокета)
 
 Для хранения данных из вебсокета добавил поле: `Message`, чтобы передать дальше данные для обработки.
 
 Поле amqp хранится в структуре hub, потому что в пакете hub происходит добавление в очередь
 
В вебсокет можно отправить сообщения, но только если проверка JWT токена произошла успешна и был определен UID, то сообщение пользователя будет отправлено в брокер сообщений.

Проверка прав реализована в пакете hub, аналогично существующим функциям.

Поправлены тесты из за изменения функции NewHub.